### PR TITLE
JPCERTの注意喚起情報のタイトルを調整

### DIFF
--- a/code.js
+++ b/code.js
@@ -267,6 +267,11 @@ function getJpcertNewHeadsUp(latestWatchedAt) {
       continue;
     }
 
+    // タイトルを調整
+    item['title'] = item['title'].replace(/^注意喚起:/, '');
+    item['title'] = item['title'].replace(/\((?:公開|更新)\)$/, '');
+    item['title'] = item['title'].trim();
+
     result.push(item);
   }
 


### PR DESCRIPTION
・先頭の「注意喚起:」を削除
・末尾の「(公開)」「(更新)」を削除